### PR TITLE
ci: build doc only for new release

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,8 @@
 name: gh-pages
 on:
   push:
-    branches:
-      - '*'
-      - '!gh-pages'
+    tags:
+      - "v*"
 
 jobs:
   build:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,8 +1,8 @@
 name: gh-pages
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types:
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
Run the gh-pages pipeline only if we have a tag corresponding to `v*`.